### PR TITLE
Task 4.2 - Refactor, use domain-defined response for use cases from external API services

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ vendor/bin/phpunit
 
 - **GET** `/api/movies/search` - Search for movies based on a query and page number. (requires authentication)
 - **GET** `/api/movies/favorites` - **TODO**
-- **POST** `/api/movies/favorites` - Adds a movie to the authenticated user's favorites list. The movie will be retrieved from an external API based on the provided `themoviedb_id`. (requires authentication)
+- **POST** `/api/movies/favorites` - Adds a movie to the authenticated user's favorites list. The movie will be retrieved from an external API based on the provided `external_id`. (requires authentication)
 - **DELETE** `/api/movies/favorites/{id}` - **TODO**
 
 
@@ -210,14 +210,14 @@ vendor/bin/phpunit
     {
       "data": [
         {
-          "themoviedb_id": 1001,
+          "external_id": 1001,
           "title": "Lore Ipsum: The Beginning",
           "overview": "In a world where text and stories are created by random generation, Lore Ipsum comes to life in an unexpected adventure of mystery and discovery.",
           "release_date": "2024-01-15",
           "poster_path": "/fakePosterPath1.jpg"
         },
         {
-          "themoviedb_id": 1002,
+          "external_id": 1002,
           "title": "Lore Ipsum: The Quest for Knowledge",
           "overview": "The second chapter in the Lore Ipsum series takes the protagonist on a thrilling journey to uncover the hidden truths of a digital world full of danger and intrigue.",
           "release_date": "2024-03-22",
@@ -255,7 +255,7 @@ vendor/bin/phpunit
 - **Request Body**:
   ```json
   {
-    "themoviedb_id": 1001
+    "external_id": 1001
   }
   ```
 
@@ -268,7 +268,7 @@ vendor/bin/phpunit
     ```
 
 - **Error Responses**:
-  - **422 Unprocessable Content** - Missing `themoviedb_id` or invalid value:
+  - **422 Unprocessable Content** - Missing `external_id` or invalid value:
     ```json
     {
       "message": "The themoviedb id field is required."

--- a/app/Application/DTOs/Movies/AddMovieToFavoritesDTO.php
+++ b/app/Application/DTOs/Movies/AddMovieToFavoritesDTO.php
@@ -8,14 +8,14 @@ use Illuminate\Http\Request;
 class AddMovieToFavoritesDTO extends BaseDTO
 {
     public function __construct(
-        public int $theMovieDbId,
+        public int $externalId,
     ) {
     }
 
     public static function makeFromRequest(Request $request): self
     {
         return new self(
-            theMovieDbId: $request->input('themoviedb_id'),
+            externalId: $request->input('external_id'),
         );
     }
 }

--- a/app/Application/DTOs/Movies/Responses/SearchMoviesExternalApiResponse.php
+++ b/app/Application/DTOs/Movies/Responses/SearchMoviesExternalApiResponse.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Application\DTOs\Movies\Responses;
+
+use App\Domain\Entities\Movie;
+
+class SearchMoviesExternalApiResponse
+{
+    public function __construct(
+        public array $movies = [],
+        public int $currentPage = 1,
+        public int $totalPages = 1,
+        public int $totalResults = 0
+    ) {
+        $this->movies = array_map(function ($movie) {
+            if (!($movie instanceof Movie)) {
+                throw new \InvalidArgumentException("Invalid movie object.", 500);
+            }
+            return $movie;
+        }, $movies);
+    }
+}

--- a/app/Application/Resources/Movies/SearchMoviesResource.php
+++ b/app/Application/Resources/Movies/SearchMoviesResource.php
@@ -9,7 +9,7 @@ class SearchMoviesResource extends JsonResource
     public function toArray($request)
     {
         return [
-            'themoviedb_id' => $this->getTheMovieDbId(),
+            'external_id' => $this->getExternalId(),
             'title' => $this->getTitle(),
             'overview' => $this->getOverview(),
             'release_date' => $this->getReleaseDate(),

--- a/app/Application/UseCases/Movies/AddMovieToFavoritesUseCase.php
+++ b/app/Application/UseCases/Movies/AddMovieToFavoritesUseCase.php
@@ -30,27 +30,19 @@ class AddMovieToFavoritesUseCase
         $movie = $this->getMovie($dto);
         $this->addToFavorites($movie);
 
-        return new GenericMessageResource("All right, movie #{$movie->getTheMovieDbId()} is in your favorites list.");
+        return new GenericMessageResource("All right, movie #{$movie->getExternalId()} is in your favorites list.");
     }
 
     private function getMovie(AddMovieToFavoritesDTO $dto): Movie
     {
-        $movie = $this->movieRepository->findByTheMovieDbId($dto->theMovieDbId);
+        $movie = $this->movieRepository->findByExternalId($dto->externalId);
 
         if (!$movie) {
-            $response = $this->externalMovieApiService->getMovie($dto->theMovieDbId);
+            $movie = $this->externalMovieApiService->getMovie($dto->externalId);
 
-            if (!$response) {
+            if (!$movie) {
                 throw new BusinessException("Movie not found.", 404, ErrorCodeEnum::MOVIE_NOT_FOUND->value);
             }
-
-            $movie = new Movie(
-                theMovieDbId: $response['id'],
-                title: $response['title'],
-                overview: $response['overview'],
-                releaseDate: $response['release_date'],
-                posterPath: $response['poster_path']
-            );
 
             $movie = $this->movieRepository->create($movie);
         }

--- a/app/Application/UseCases/Movies/SearchMoviesUseCase.php
+++ b/app/Application/UseCases/Movies/SearchMoviesUseCase.php
@@ -4,43 +4,27 @@ namespace App\Application\UseCases\Movies;
 
 use App\Application\DTOs\Movies\SearchMoviesDTO;
 use App\Application\Resources\Movies\SearchMoviesResource;
-use App\Domain\Entities\Movie;
-use App\Infrastructure\Services\Movies\TheMovieDbService;
+use App\Domain\Interfaces\Services\ExternalMovieApiServiceInterface;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 
 class SearchMoviesUseCase
 {
-    private TheMovieDbService $theMovieDbService;
+    private ExternalMovieApiServiceInterface $externalMovieApiService;
 
-    public function __construct(TheMovieDbService $theMovieDbService)
+    public function __construct(ExternalMovieApiServiceInterface $externalMovieApiService)
     {
-        $this->theMovieDbService = $theMovieDbService;
+        $this->externalMovieApiService = $externalMovieApiService;
     }
 
     public function execute(SearchMoviesDTO $dto): AnonymousResourceCollection
     {
-        $response = $this->theMovieDbService->searchMovies($dto->query, $dto->page);
-        $moviesData = $response['results'] ?? [];
+        $response = $this->externalMovieApiService->searchMovies($dto->query, $dto->page);
 
-        $movies = [];
-
-        foreach ($moviesData as $movieData) {
-            $movie = new Movie(
-                theMovieDbId: $movieData['id'],
-                title: $movieData['title'],
-                overview: $movieData['overview'] ?? null,
-                releaseDate: $movieData['release_date'],
-                posterPath: $movieData['poster_path'] ?? null,
-            );
-
-            $movies[] = $movie;
-        }
-
-        return SearchMoviesResource::collection($movies)->additional([
+        return SearchMoviesResource::collection($response->movies)->additional([
             'meta' => [
-                'current_page' => $response['page'] ?? $dto->page,
-                'total_pages' => $response['total_pages'] ?? 0,
-                'total_results' => $response['total_results'] ?? 0,
+                'current_page' => $response->currentPage ?? $dto->page,
+                'total_pages' => $response->totalPages ?? 1,
+                'total_results' => $response->totalResults ?? 0,
             ]
         ]);
     }

--- a/app/Domain/Entities/Movie.php
+++ b/app/Domain/Entities/Movie.php
@@ -5,14 +5,14 @@ namespace App\Domain\Entities;
 class Movie
 {
     private ?int $id;
-    private int $theMovieDbId;
+    private int $externalId;
     private string $title;
     private ?string $overview;
     private string $releaseDate;
     private ?string $posterPath;
 
     public function __construct(
-        int $theMovieDbId,
+        int $externalId,
         string $title,
         ?string $overview,
         string $releaseDate,
@@ -20,7 +20,7 @@ class Movie
         ?int $id = null,
     ) {
         $this->id = $id;
-        $this->theMovieDbId = $theMovieDbId;
+        $this->externalId = $externalId;
         $this->title = $title;
         $this->overview = $overview;
         $this->releaseDate = $releaseDate;
@@ -37,9 +37,9 @@ class Movie
         $this->id = $id;
     }
 
-    public function getTheMovieDbId(): int
+    public function getExternalId(): int
     {
-        return $this->theMovieDbId;
+        return $this->externalId;
     }
 
     public function getTitle(): string

--- a/app/Domain/Interfaces/Repositories/MovieRepositoryInterface.php
+++ b/app/Domain/Interfaces/Repositories/MovieRepositoryInterface.php
@@ -9,7 +9,7 @@ interface MovieRepositoryInterface
 {
     public function findById(int $id): ?Movie;
 
-    public function findByTheMovieDbId(int $theMovieDbId): ?Movie;
+    public function findByExternalId(int $externalId): ?Movie;
 
     public function create(Movie $movie): Movie;
 

--- a/app/Domain/Interfaces/Services/ExternalMovieApiServiceInterface.php
+++ b/app/Domain/Interfaces/Services/ExternalMovieApiServiceInterface.php
@@ -2,8 +2,11 @@
 
 namespace App\Domain\Interfaces\Services;
 
+use App\Application\DTOs\Movies\Responses\SearchMoviesExternalApiResponse;
+use App\Domain\Entities\Movie;
+
 interface ExternalMovieApiServiceInterface
 {
-    public function searchMovies(string $query, int $page = 1): ?array;
-    public function getMovie(int $movieId): ?array;
+    public function searchMovies(string $query, int $page = 1): SearchMoviesExternalApiResponse;
+    public function getMovie(int $movieId): ?Movie;
 }

--- a/app/Infrastructure/Persistence/Factories/MovieFactory.php
+++ b/app/Infrastructure/Persistence/Factories/MovieFactory.php
@@ -14,7 +14,7 @@ class MovieFactory
         $createdMovie = MovieEloquentModel::factory()->create($data);
 
         return new Movie(
-            $createdMovie->themoviedb_id,
+            $createdMovie->external_id,
             $createdMovie->title,
             $createdMovie->overview,
             $createdMovie->release_date,

--- a/app/Infrastructure/Persistence/Models/MovieEloquentModel.php
+++ b/app/Infrastructure/Persistence/Models/MovieEloquentModel.php
@@ -13,7 +13,7 @@ class MovieEloquentModel extends Model
     protected $table = 'movies';
 
     protected $fillable = [
-        'themoviedb_id',
+        'external_id',
         'title',
         'overview',
         'release_date',

--- a/app/Infrastructure/Persistence/Repositories/EloquentMovieRepository.php
+++ b/app/Infrastructure/Persistence/Repositories/EloquentMovieRepository.php
@@ -19,7 +19,7 @@ class EloquentMovieRepository implements MovieRepositoryInterface
         }
 
         return new Movie(
-            $movie->themoviedb_id,
+            $movie->external_id,
             $movie->title,
             $movie->overview,
             $movie->release_date,
@@ -28,16 +28,16 @@ class EloquentMovieRepository implements MovieRepositoryInterface
         );
     }
 
-    public function findByTheMovieDbId(int $theMovieDbId): ?Movie
+    public function findByExternalId(int $externalId): ?Movie
     {
-        $movie = MovieEloquentModel::where('themoviedb_id', $theMovieDbId)->first();
+        $movie = MovieEloquentModel::where('external_id', $externalId)->first();
 
         if (!$movie) {
             return null;
         }
 
         return new Movie(
-            $movie->themoviedb_id,
+            $movie->external_id,
             $movie->title,
             $movie->overview,
             $movie->release_date,
@@ -49,7 +49,7 @@ class EloquentMovieRepository implements MovieRepositoryInterface
     public function create(Movie $movie): Movie
     {
         $model = new MovieEloquentModel([
-            'themoviedb_id' => $movie->getTheMovieDbId(),
+            'external_id' => $movie->getExternalId(),
             'title' => $movie->getTitle(),
             'overview' => $movie->getOverview(),
             'release_date' => $movie->getReleaseDate(),

--- a/app/Infrastructure/RequestValidators/Movies/AddMovieToFavoritesRequest.php
+++ b/app/Infrastructure/RequestValidators/Movies/AddMovieToFavoritesRequest.php
@@ -14,7 +14,7 @@ class AddMovieToFavoritesRequest extends FormRequest
     public function rules()
     {
         return [
-            'themoviedb_id' => 'integer|required'
+            'external_id' => 'integer|required'
         ];
     }
 }

--- a/app/Infrastructure/Services/Movies/TheMovieDbService.php
+++ b/app/Infrastructure/Services/Movies/TheMovieDbService.php
@@ -2,6 +2,8 @@
 
 namespace App\Infrastructure\Services\Movies;
 
+use App\Application\DTOs\Movies\Responses\SearchMoviesExternalApiResponse;
+use App\Domain\Entities\Movie;
 use App\Domain\Interfaces\Services\ExternalMovieApiServiceInterface;
 use Illuminate\Support\Facades\Http;
 
@@ -16,7 +18,7 @@ class TheMovieDbService implements ExternalMovieApiServiceInterface
         $this->apiKey = config('themoviedb.api_key');
     }
 
-    public function searchMovies(string $query, int $page = 1): ?array
+    public function searchMovies(string $query, int $page = 1): SearchMoviesExternalApiResponse
     {
         $response = Http::get("{$this->apiBaseUrl}/search/movie", [
             'api_key' => $this->apiKey,
@@ -24,10 +26,23 @@ class TheMovieDbService implements ExternalMovieApiServiceInterface
             'page' => $page
         ])->throwUnlessStatus(200);
 
-        return $response->json();
+        return new SearchMoviesExternalApiResponse(
+            currentPage: $response['page'],
+            totalPages: $response['total_pages'],
+            totalResults: $response['total_results'],
+            movies: collect($response['results'])->map(function ($movieData) {
+                return new Movie(
+                    externalId: $movieData['id'],
+                    title: $movieData['title'],
+                    overview: $movieData['overview'] ?? null,
+                    releaseDate: $movieData['release_date'],
+                    posterPath: $movieData['poster_path'] ?? null
+                );
+            })->toArray()
+        );
     }
 
-    public function getMovie(int $movieId): ?array
+    public function getMovie(int $movieId): ?Movie
     {
         $response = Http::get("{$this->apiBaseUrl}/movie/{$movieId}", [
             'api_key' => $this->apiKey
@@ -39,6 +54,14 @@ class TheMovieDbService implements ExternalMovieApiServiceInterface
             return null;
         }
 
-        return $response->json();
+        $response = $response->json();
+
+        return new Movie(
+            externalId: $response['id'],
+            title: $response['title'],
+            overview: $response['overview'],
+            releaseDate: $response['release_date'],
+            posterPath: $response['poster_path']
+        );
     }
 }

--- a/database/migrations/2024_11_15_134802_create_table_movies.php
+++ b/database/migrations/2024_11_15_134802_create_table_movies.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::create('movies', function (Blueprint $table) {
             $table->id();
-            $table->string('themoviedb_id')->index();
+            $table->string('external_id')->index();
             $table->string('title');
             $table->text('overview')->nullable();
             $table->date('release_date');

--- a/tests/Feature/Movies/AddMovieToFavoritesTest.php
+++ b/tests/Feature/Movies/AddMovieToFavoritesTest.php
@@ -40,10 +40,10 @@ class AddMovieToFavoritesTest extends TestCase
     #[Test]
     public function itShouldSuccessfullyFavoriteMovie(): void
     {
-        $theMovieDbId = 1001;
+        $externalId = 1001;
 
         Http::fake([
-            "https://api.themoviedb.org/3/movie/{$theMovieDbId}*" => Http::response(
+            "https://api.themoviedb.org/3/movie/{$externalId}*" => Http::response(
                 file_get_contents(base_path('tests/mocks/movies/show-success.json')),
                 200
             ),
@@ -53,19 +53,19 @@ class AddMovieToFavoritesTest extends TestCase
             'POST',
             '/api/movies/favorites',
             [
-                'themoviedb_id' => $theMovieDbId,
+                'external_id' => $externalId,
             ],
             $this->headerWithToken
         )
             ->assertStatus(200)
             ->assertJsonFragment([
-                'message' => "All right, movie #{$theMovieDbId} is in your favorites list.",
+                'message' => "All right, movie #{$externalId} is in your favorites list.",
             ])
             ->json();
 
-        $persistedMovie = DB::table('movies')->where('themoviedb_id', $theMovieDbId)->first();
+        $persistedMovie = DB::table('movies')->where('external_id', $externalId)->first();
 
-        $this->assertEquals($theMovieDbId, $persistedMovie->themoviedb_id);
+        $this->assertEquals($externalId, $persistedMovie->external_id);
         $this->assertEquals('Lore Ipsum: The Beginning', $persistedMovie->title);
         $this->assertEquals('In a world where text and stories are created by random generation, Lore Ipsum comes to life in an unexpected adventure of mystery and discovery.', $persistedMovie->overview);
         $this->assertEquals('2024-01-15', $persistedMovie->release_date);
@@ -80,10 +80,10 @@ class AddMovieToFavoritesTest extends TestCase
     #[Test]
     public function itShouldSuccessfullyFavoriteMovieEvenIfTheMovieIsAlreadyPersistedBefore(): void
     {
-        $theMovieDbId = 1001;
+        $externalId = 1001;
 
         $persistedMovie = MovieFactory::create([
-            'themoviedb_id' => $theMovieDbId,
+            'external_id' => $externalId,
             'title' => 'Lore Ipsum: The Beginning',
             'overview' => 'In a world where text and stories are created by random generation, Lore Ipsum comes to life in an unexpected adventure of mystery and discovery.',
             'release_date' => '2024-01-15',
@@ -91,7 +91,7 @@ class AddMovieToFavoritesTest extends TestCase
         ]);
 
         Http::fake([
-            "https://api.themoviedb.org/3/movie/{$theMovieDbId}*" => Http::response(
+            "https://api.themoviedb.org/3/movie/{$externalId}*" => Http::response(
                 file_get_contents(base_path('tests/mocks/movies/show-success.json')),
                 200
             ),
@@ -101,17 +101,17 @@ class AddMovieToFavoritesTest extends TestCase
             'POST',
             '/api/movies/favorites',
             [
-                'themoviedb_id' => $theMovieDbId,
+                'external_id' => $externalId,
             ],
             $this->headerWithToken
         )
             ->assertStatus(200)
             ->assertJsonFragment([
-                'message' => "All right, movie #{$theMovieDbId} is in your favorites list.",
+                'message' => "All right, movie #{$externalId} is in your favorites list.",
             ])
             ->json();
 
-        $this->assertEquals($theMovieDbId, $persistedMovie->getTheMovieDbId());
+        $this->assertEquals($externalId, $persistedMovie->getExternalId());
         $this->assertEquals('Lore Ipsum: The Beginning', $persistedMovie->getTitle());
         $this->assertEquals('In a world where text and stories are created by random generation, Lore Ipsum comes to life in an unexpected adventure of mystery and discovery.', $persistedMovie->getOverview());
         $this->assertEquals('2024-01-15 00:00:00', $persistedMovie->getReleaseDate());
@@ -121,10 +121,10 @@ class AddMovieToFavoritesTest extends TestCase
     #[Test]
     public function itShouldNotFoundWhenShowMovie(): void
     {
-        $theMovieDbId = 1001;
+        $externalId = 1001;
 
         Http::fake([
-            "https://api.themoviedb.org/3/movie/{$theMovieDbId}*" => Http::response(
+            "https://api.themoviedb.org/3/movie/{$externalId}*" => Http::response(
                 file_get_contents(base_path('tests/mocks/movies/show-not-found.json')),
                 404
             ),
@@ -134,7 +134,7 @@ class AddMovieToFavoritesTest extends TestCase
             'POST',
             '/api/movies/favorites',
             [
-                'themoviedb_id' => $theMovieDbId,
+                'external_id' => $externalId,
             ],
             $this->headerWithToken
         )
@@ -151,10 +151,10 @@ class AddMovieToFavoritesTest extends TestCase
     #[Test]
     public function itShouldNotFavoriteMovieIfAlreadyFavorited(): void
     {
-        $theMovieDbId = 1001;
+        $externalId = 1001;
 
         $persistedMovie = MovieFactory::create([
-            'themoviedb_id' => $theMovieDbId,
+            'external_id' => $externalId,
             'title' => 'Lore Ipsum: The Beginning',
             'overview' => 'In a world where text and stories are created by random generation, Lore Ipsum comes to life in an unexpected adventure of mystery and discovery.',
             'release_date' => '2024-01-15',
@@ -167,7 +167,7 @@ class AddMovieToFavoritesTest extends TestCase
         ]);
 
         Http::fake([
-            "https://api.themoviedb.org/3/movie/{$theMovieDbId}*" => Http::response(
+            "https://api.themoviedb.org/3/movie/{$externalId}*" => Http::response(
                 file_get_contents(base_path('tests/mocks/movies/show-success.json')),
                 200
             ),
@@ -177,7 +177,7 @@ class AddMovieToFavoritesTest extends TestCase
             'POST',
             '/api/movies/favorites',
             [
-                'themoviedb_id' => $theMovieDbId,
+                'external_id' => $externalId,
             ],
             $this->headerWithToken
         )
@@ -197,7 +197,7 @@ class AddMovieToFavoritesTest extends TestCase
             'POST',
             '/api/movies/favorites',
             [
-                'themoviedb_id' => 1000,
+                'external_id' => 1000,
             ],
             [
                 'Authorization' => 'Bearer wrongtoken'
@@ -211,7 +211,7 @@ class AddMovieToFavoritesTest extends TestCase
     }
 
     #[Test]
-    public function itShouldRequireTheMovieDbIdParameter(): void
+    public function itShouldRequireExternalIdParameter(): void
     {
         $this->json(
             'POST',
@@ -221,7 +221,7 @@ class AddMovieToFavoritesTest extends TestCase
         )
             ->assertStatus(422)
             ->assertJsonFragment([
-                'message' => 'The themoviedb id field is required.',
+                'message' => 'The external id field is required.',
             ]);
     }
 }

--- a/tests/Feature/Movies/SearchMoviesTest.php
+++ b/tests/Feature/Movies/SearchMoviesTest.php
@@ -70,13 +70,13 @@ class SearchMoviesTest extends TestCase
                 $request->data()['page'] === $page;
         });
 
-        $this->assertEquals(1001, $response['data'][0]['themoviedb_id']);
+        $this->assertEquals(1001, $response['data'][0]['external_id']);
         $this->assertEquals('Lore Ipsum: The Beginning', $response['data'][0]['title']);
         $this->assertEquals('In a world where text and stories are created by random generation, Lore Ipsum comes to life in an unexpected adventure of mystery and discovery.', $response['data'][0]['overview']);
         $this->assertEquals('2024-01-15', $response['data'][0]['release_date']);
         $this->assertEquals('/fakePosterPath1.jpg', $response['data'][0]['poster_path']);
 
-        $this->assertEquals(1002, $response['data'][1]['themoviedb_id']);
+        $this->assertEquals(1002, $response['data'][1]['external_id']);
         $this->assertEquals('Lore Ipsum: The Quest for Knowledge', $response['data'][1]['title']);
         $this->assertEquals('The second chapter in the Lore Ipsum series takes the protagonist on a thrilling journey to uncover the hidden truths of a digital world full of danger and intrigue.', $response['data'][1]['overview']);
         $this->assertEquals('2024-03-22', $response['data'][1]['release_date']);


### PR DESCRIPTION
This PR refactors the application to ensure that use cases receive a domain-defined response from the external API services. 

The services now implement the respective interfaces and return consistent responses, which are used by the use cases.

Additionally, the `external_id` field replaces `themoviedb_id` for better flexibility with different external APIs.
